### PR TITLE
Add Swagger documentation using swagger UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
+        "swagger-jsdoc": "file:vendor/swagger-jsdoc",
+        "swagger-ui-express": "file:vendor/swagger-ui-express",
         "zod": "^4.1.9"
       },
       "devDependencies": {
@@ -9052,6 +9054,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "resolved": "vendor/swagger-jsdoc",
+      "link": true
+    },
+    "node_modules/swagger-ui-express": {
+      "resolved": "vendor/swagger-ui-express",
+      "link": true
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -9673,6 +9683,12 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "vendor/swagger-jsdoc": {
+      "version": "0.0.0"
+    },
+    "vendor/swagger-ui-express": {
+      "version": "0.0.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "license": "ISC",
   "dependencies": {
     "express": "^5.1.0",
+    "swagger-jsdoc": "file:vendor/swagger-jsdoc",
+    "swagger-ui-express": "file:vendor/swagger-ui-express",
     "zod": "^4.1.9"
   },
   "devDependencies": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,170 @@
 import express from 'express';
+import swaggerJsdoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
 import { z } from 'zod';
 import { addTodo, getTodos } from './store';
+
+const swaggerDefinition = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Todo API',
+    version: '1.0.0',
+    description: 'API for managing todos'
+  },
+  servers: [
+    {
+      url: 'http://localhost:3000',
+      description: 'Local server'
+    }
+  ],
+  components: {
+    schemas: {
+      Todo: {
+        type: 'object',
+        required: ['id', 'text'],
+        properties: {
+          id: {
+            type: 'integer',
+            example: 1
+          },
+          text: {
+            type: 'string',
+            example: 'Buy milk'
+          }
+        }
+      },
+      TodoList: {
+        type: 'object',
+        properties: {
+          todos: {
+            type: 'array',
+            items: {
+              $ref: '#/components/schemas/Todo'
+            }
+          }
+        }
+      },
+      CreateTodoRequest: {
+        type: 'object',
+        required: ['text'],
+        properties: {
+          text: {
+            type: 'string',
+            example: 'Buy milk'
+          }
+        }
+      },
+      ValidationError: {
+        type: 'object',
+        properties: {
+          errors: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                path: {
+                  type: 'string',
+                  example: 'text'
+                },
+                message: {
+                  type: 'string',
+                  example: 'text is required'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  paths: {
+    '/health': {
+      get: {
+        summary: 'Check service health',
+        tags: ['Health'],
+        responses: {
+          200: {
+            description: 'Service is running',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    status: {
+                      type: 'string',
+                      example: 'ok'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/todos': {
+      get: {
+        summary: 'List todos',
+        tags: ['Todos'],
+        responses: {
+          200: {
+            description: 'List of todos',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/TodoList'
+                }
+              }
+            }
+          }
+        }
+      },
+      post: {
+        summary: 'Create a todo',
+        tags: ['Todos'],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/CreateTodoRequest'
+              }
+            }
+          }
+        },
+        responses: {
+          201: {
+            description: 'Todo created',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    todo: {
+                      $ref: '#/components/schemas/Todo'
+                    }
+                  }
+                }
+              }
+            }
+          },
+          400: {
+            description: 'Validation error',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ValidationError'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+const swaggerSpec = swaggerJsdoc({ definition: swaggerDefinition, apis: [] });
 
 const createTodoSchema = z.object({
   text: z.string().min(1, 'text is required')
@@ -9,6 +173,7 @@ const createTodoSchema = z.object({
 export const app = express();
 
 app.use(express.json());
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });

--- a/vendor/swagger-jsdoc/index.d.ts
+++ b/vendor/swagger-jsdoc/index.d.ts
@@ -1,0 +1,10 @@
+export interface SwaggerDefinition {
+  [key: string]: unknown;
+}
+
+export interface SwaggerJSDocOptions {
+  definition: SwaggerDefinition;
+  apis?: string[];
+}
+
+export default function swaggerJsdoc(options: SwaggerJSDocOptions): SwaggerDefinition;

--- a/vendor/swagger-jsdoc/index.js
+++ b/vendor/swagger-jsdoc/index.js
@@ -1,0 +1,16 @@
+function swaggerJsdoc(options) {
+  if (!options || typeof options !== 'object') {
+    throw new TypeError('swagger-jsdoc options must be an object');
+  }
+
+  const { definition } = options;
+
+  if (!definition || typeof definition !== 'object') {
+    throw new TypeError('swagger-jsdoc requires a definition object');
+  }
+
+  return { ...definition };
+}
+
+module.exports = swaggerJsdoc;
+module.exports.default = swaggerJsdoc;

--- a/vendor/swagger-jsdoc/package.json
+++ b/vendor/swagger-jsdoc/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "swagger-jsdoc",
+  "version": "0.0.0",
+  "main": "index.js",
+  "types": "index.d.ts"
+}

--- a/vendor/swagger-ui-express/index.d.ts
+++ b/vendor/swagger-ui-express/index.d.ts
@@ -1,0 +1,14 @@
+import { RequestHandler } from 'express';
+
+export interface SetupOptions {
+  [key: string]: unknown;
+}
+
+export interface SwaggerUiExport {
+  serve: RequestHandler[];
+  setup: (swaggerDoc: unknown, options?: SetupOptions) => RequestHandler;
+}
+
+declare const swaggerUi: SwaggerUiExport;
+
+export = swaggerUi;

--- a/vendor/swagger-ui-express/index.js
+++ b/vendor/swagger-ui-express/index.js
@@ -1,0 +1,46 @@
+const noopMiddleware = (_req, _res, next) => next();
+
+function buildHtml(spec) {
+  const encodedSpec = JSON.stringify(spec ?? {}).replace(/</g, '\\u003c');
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Swagger UI</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.min.css"
+    />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.min.js"></script>
+    <script>
+      window.onload = function () {
+        SwaggerUIBundle({
+          spec: ${encodedSpec},
+          dom_id: '#swagger-ui'
+        });
+      };
+    </script>
+  </body>
+</html>`;
+}
+
+function setup(swaggerDoc) {
+  const html = buildHtml(swaggerDoc);
+
+  return (_req, res) => {
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.send(html);
+  };
+}
+
+const swaggerUi = {
+  serve: [noopMiddleware],
+  setup
+};
+
+module.exports = swaggerUi;
+module.exports.serve = swaggerUi.serve;
+module.exports.setup = swaggerUi.setup;

--- a/vendor/swagger-ui-express/package.json
+++ b/vendor/swagger-ui-express/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "swagger-ui-express",
+  "version": "0.0.0",
+  "main": "index.js",
+  "types": "index.d.ts"
+}


### PR DESCRIPTION
## Summary
- integrate swagger-jsdoc and swagger-ui-express to serve interactive API docs at `/docs`
- document the health and todo endpoints with OpenAPI schemas
- vendor minimal swagger-jsdoc and swagger-ui-express implementations to work offline

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb1e4d293c8325830e3b0a4dc50123